### PR TITLE
Bump dependencies

### DIFF
--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 bytes = "0.4"
-base64 = "0.6"
+base64 = "0.10"
 futures = "0.1"
 hyper = "0.11"
 winauth = { path = "../winauth" }

--- a/hyper/src/lib.rs
+++ b/hyper/src/lib.rs
@@ -153,17 +153,20 @@ impl<T> Future for WinAuthFuture<T>
                             // check if this is the initial request (not containing any bytes)
                             if elem.is_none() {
                                 assert!(self.winauth.is_none());
-                                let winauth = match self.inner.auth {
-                                    #[cfg(windows)]
-                                    AuthMethod::SSPI_SSO => {
-                                        Box::new(winauth::windows::NtlmSspiBuilder::new().build()?)
-                                    }
-                                    AuthMethod::NTLMv2(_, _) => {
-                                        // Box::new(winauth::NtlmV2ClientBuilder::build(
-                                        unimplemented!()
-                                    }
-                                };
-                                self.winauth = Some(winauth);
+                                #[allow(unreachable_code, unused_variables)]
+                                {
+                                    let winauth = match self.inner.auth {
+                                        #[cfg(windows)]
+                                        AuthMethod::SSPI_SSO => {
+                                            Box::new(winauth::windows::NtlmSspiBuilder::new().build()?)
+                                        }
+                                        AuthMethod::NTLMv2(_, _) => {
+                                            // Box::new(winauth::NtlmV2ClientBuilder::build(
+                                            unimplemented!()
+                                        }
+                                    };
+                                    self.winauth = Some(winauth);
+                                }
                             }
                             let next = self.winauth.as_mut().unwrap()
                                            .next_bytes(elem.as_ref().map(|x| &**x))?;

--- a/winauth/Cargo.toml
+++ b/winauth/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["ntlm", "sspi", "winauth"]
 [dependencies]
 bitflags = "1.0"
 byteorder = "1.2.0"
-rand = "0.4"
-md5 = "0.3.3"
+rand = "0.7"
+md5 = "0.6.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winerror", "sspi"] }

--- a/winauth/src/lib.rs
+++ b/winauth/src/lib.rs
@@ -18,7 +18,7 @@ use std::env;
 use std::io::{self, Cursor, Read, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 use byteorder::{ByteOrder, WriteBytesExt, ReadBytesExt, LittleEndian};
-use rand::Rng;
+use rand::prelude::*;
 
 mod hmac;
 mod md4;
@@ -71,8 +71,8 @@ macro_rules! uint_to_enum {
     }
 }
 
-/// as documented in 2.2.2.5 NEGOTIATE
 bitflags! {
+    /// as documented in 2.2.2.5 NEGOTIATE
     struct NegotiateFlags: u32 {
         /// W-bit
         /// requests 56-bit encryption
@@ -599,7 +599,7 @@ impl<'a> Ntlmv2Response<'a> {
         };
         try!(w.write_u64::<LittleEndian>(nano_seconds));
         let mut client_challenge = [0u8; 8];
-        rand::thread_rng().fill_bytes(&mut client_challenge);
+        thread_rng().fill_bytes(&mut client_challenge);
         try!(w.write_all(&client_challenge));
         try!(w.write_u32::<LittleEndian>(0)); //reserved3
         try!(w.encode_av_pairs(&self.av_pairs));
@@ -623,7 +623,7 @@ impl<'a> Ntlmv2Response<'a> {
         let session_base_key = Md5::hmac(&response_key_nt, &nt_proof_str);
         // ExportedSessionKey := NONCE(16)
         let mut exported_session_key = [0u8; 16];
-        rand::thread_rng().fill_bytes(&mut exported_session_key);
+        thread_rng().fill_bytes(&mut exported_session_key);
         let encrypted_random_session_key = rc4::rc4(&session_base_key, &exported_session_key);
 
         let mut ntlmv2_response = nt_proof_str;


### PR DESCRIPTION
This bumps `base64`, `rand`, and `md5`, which are all very common dependencies, so that downstream crates do not have to build multiple versions of those crates. I did not bump `hyper` (which _really_ needs bumping) because that requires a decent amount more work. The move from `0.11` to `0.12` is not straightforward.

In the process I also fixed a warning that appears on newer versions of the Rust compiler.